### PR TITLE
fixes and updates to initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module for deploying and managing a CloudFront web distribution backed
 ----------------------
 #### Required
 
-- bucket_fqdn
+- bucket_name
 - bucket_cors_allowed_origins
 - cloudfront_fqdn
 - dns_toplevel_zone
@@ -24,7 +24,7 @@ Usage
 module "static_web" {
   source                            = "github.com/terraform-community-modules/tf_aws_s3_cloudfront?ref=v0.0.1"
   region                            = "${data.aws_region.current.name}"
-  bucket_fqdn                       = "static-bucket.mydomain.com"
+  bucket_name                       = "static-bucket"
   bucket_cors_allowed_origins       = ["static.mydomain.com"]
   cloudfront_fqdn                   = "static.mydomain.com"
   dns_toplevel_zone                 = "mydomain.com"

--- a/data.tf
+++ b/data.tf
@@ -24,12 +24,6 @@ data "aws_iam_policy_document" "bucket_policy_document" {
   }
 }
 
-resource "aws_iam_policy" "bucket_policy" {
-  name_prefix = "${var.short_name}"
-  path        = "${var.iam_policy_path}"
-  policy      = "${data.aws_iam_policy_document.bucket_policy_document.json}"
-}
-
 resource "aws_s3_bucket" "bucket" {
   bucket        = "${var.bucket_name}"
   acl           = "${var.bucket_acl}"

--- a/data.tf
+++ b/data.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "bucket_policy_document" {
   statement {
     sid       = "1"
     actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${var.bucket_fqdn}{$var.iam_policy_resources_path}"]
+    resources = ["arn:aws:s3:::${var.bucket_name}${var.iam_policy_resources_path}"]
 
     principals {
       type        = "AWS"
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "bucket_policy_document" {
   statement {
     sid       = "2"
     actions   = ["s3:ListBucket"]
-    resources = ["arn:aws:s3:::${var.bucket_fqdn}"]
+    resources = ["arn:aws:s3:::${var.bucket_name}"]
 
     principals {
       type        = "AWS"
@@ -31,7 +31,7 @@ resource "aws_iam_policy" "bucket_policy" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${var.bucket_fqdn}"
+  bucket        = "${var.bucket_name}"
   acl           = "${var.bucket_acl}"
   region        = "${data.aws_region.region.name}"
   force_destroy = "${var.bucket_force_destroy}"

--- a/data.tf
+++ b/data.tf
@@ -43,6 +43,6 @@ resource "aws_s3_bucket" "bucket" {
 
 # outputs from data tier
 
-output "S3 bucket domain name" {
+output "s3_bucket_domain_name" {
   value = "${aws_s3_bucket.bucket.bucket_domain_name}"
 }

--- a/edge.tf
+++ b/edge.tf
@@ -1,6 +1,7 @@
 # Edge - Route 53 and CloudFront
 
 resource "aws_route53_record" "cloudfront_a" {
+  count   = "${(var.cloudfront_fqdn != "") ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.zone.zone_id}"
   name    = "${var.cloudfront_fqdn}"
   type    = "A"
@@ -13,6 +14,7 @@ resource "aws_route53_record" "cloudfront_a" {
 }
 
 resource "aws_route53_record" "cloudfront_aaaa" {
+  count   = "${(var.cloudfront_fqdn != "") ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.zone.zone_id}"
   name    = "${var.cloudfront_fqdn}"
   type    = "AAAA"
@@ -25,7 +27,7 @@ resource "aws_route53_record" "cloudfront_aaaa" {
 }
 
 resource "aws_cloudfront_origin_access_identity" "identity" {
-  comment = "CloudFront access to S3 bucket ${var.bucket_fqdn}"
+  comment = "CloudFront access to S3 bucket ${var.bucket_name}"
 }
 
 resource "aws_cloudfront_distribution" "cloudfront" {

--- a/edge.tf
+++ b/edge.tf
@@ -83,14 +83,14 @@ resource "aws_cloudfront_distribution" "cloudfront" {
 
 # outputs from edge tier
 
-output "CloudFront FQDN" {
+output "cloudfront_fqdn" {
   value = "${aws_cloudfront_distribution.cloudfront.domain_name}"
 }
 
-output "CloudFront A record" {
+output "cloudfront_a_record" {
   value = "${aws_route53_record.cloudfront_a.fqdn}"
 }
 
-output "CloudFront S3 bucket source path" {
+output "cloudfront_s3_bucket_source_path" {
   value = "${aws_s3_bucket.bucket.bucket_domain_name}/${var.cloudfront_origin_path}"
 }

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@
 provider "aws" {
   alias   = "provided"
   profile = "${var.aws_profile}"
-  region  = "${var.region}"
+  region  = "us-east-1"
 }
 
 data "aws_region" "region" {
-  name = "${var.region}"
+  name = "us-east-1"
 }
 
 data "aws_route53_zone" "zone" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,10 +30,6 @@ variable "dns_toplevel_zone" {
   type        = "string"
 }
 
-variable "iam_policy_path" {
-  default = ""
-}
-
 variable "iam_policy_resources_path" {
   description = "path inside bucket for policy, default /*"
   default = "/*"

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "short_name" {
   type = "string"
 }
 
-variable "bucket_fqdn" {
+variable "bucket_name" {
   description = "Full name for S3 bucket"
   type = "string"
 }
@@ -22,6 +22,7 @@ variable "bucket_fqdn" {
 variable "cloudfront_fqdn" {
   description = "FQDN for the cloudfront distribution"
   type = "string"
+  default = ""
 }
 
 variable "dns_toplevel_zone" {


### PR DESCRIPTION
- fix typo in bucket policy document resources path
- rename bucket_fqdn to more appropriate bucket_name
- allow to not create route53 records
- AWS requires us-east-1 for cloudfront acm cert