### PR TITLE
fix variable names and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,50 @@
-tf_aws_ecs_service
+tf_aws_s3_cloudfront
 ===========
 
-Terraform module for deploying and managing a CloudFront web distribution backed by an S3 bucket.
+Terraform module for deploying and managing a CloudFront web distribution backed by an S3 bucket. Also adds Route 53 A records to the CloudFront distribution.
 
 ----------------------
 #### Required
 
-- bucket_name
-- bucket_cors_allowed_origins
-- cloudfront_fqdn
-- dns_toplevel_zone
-- cloudfront_viewer_acm_cert_domain
-- region
-- short_name
+- bucket_name                (name for the S3 bucket to be created)
+- s3_region                  (region for the S3 bucket)
+- cloudfront_fqdn            (Route 53 record to create to the CloudFront)
+- cloudfront_acm_cert_domain (existing ACM Certificate domain to use on CloudFront)
+- route53_toplevel_zone      (existing top-level DNS domain for the Route53 record)
+
+* Note if you do not want Route 53 records created pointing to the cloudfront distribution you can optionally not pass in cloudfront_fqdn. In this case you must specify cloudfront_aliases.
 
 #### Optional
+
+Optional value                                            Default
+
+- iam_policy_resources_path                               "/*"
+- bucket_acl                                              "private"
+- bucket_force_destroy                                    false
+- bucket_cors_allowed_headers                             ["*"]
+- bucket_cors_extra_allowed_origins                       []
+- bucket_cors_expose_headers                              ["ETag"]
+- bucket_cors_max_age_seconds                             3000
+- cloudfront_origin_path                                  ""
+- cloudfront_comment                                      ""
+- cloudfront_default_root_object                          "index.html"
+- cloudfront_aliases                                      []
+- cloudfront_price_class                                  "PriceClass_All"
+- cloudfront_default_cache_allowed_methods
+                ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+- cloudfront_default_cache_cached_methods                 ["GET", "HEAD"]
+- cloudfront_default_cache_compress                       true
+- cloudfront_default_cache_default_ttl                    0
+- cloudfront_default_cache_max_ttl                        0
+- cloudfront_default_cache_min_ttl                        0
+- cloudfront_default_cache_viewer_protocol_policy         "redirect-to-https"
+- cloudfront_default_cache_forwarded_values_query_string  false
+- cloudfront_default_cache_forwarded_cookies              "all"
+- cloudfront_geo_restriction_type                         "none"
+- cloudfront_cert_min_supported_version                   "TLSv1"
+- cloudfront_cert_ssl_support_method                      "sni-only"
+- cloudfront_enabled                                      true
+- cloudfront_ipv6_enabled                                 true
 
 Usage
 -----
@@ -22,24 +52,20 @@ Usage
 ```hcl
 
 module "static_web" {
-  source                            = "github.com/terraform-community-modules/tf_aws_s3_cloudfront?ref=v0.0.1"
-  region                            = "${data.aws_region.current.name}"
-  bucket_name                       = "static-bucket"
-  bucket_cors_allowed_origins       = ["static.mydomain.com"]
+  source                            = "github.com/terraform-community-modules/tf_aws_s3_cloudfront?ref=v0.0.3"
+  bucket_name                       = "static-bucket-mydomain"
+  s3_region                         = "${data.aws_region.current.name}"
   cloudfront_fqdn                   = "static.mydomain.com"
-  dns_toplevel_zone                 = "mydomain.com"
-  cloudfront_viewer_acm_cert_domain = "mydomain.com"
-  short_name                        = "static-mydomain"
+  cloudfront_acm_cert_domain        = "mydomain.com"
+  route53_toplevel_domain           = "mydomain.com"
 }
 ```
 
 Outputs
 =======
 
-- S3 bucket domain name
-- CloudFront FQDN
-- CloudFront A record
-- CloudFront S3 bucket source path
+- cloudfront_domain_name
+- cloudfront_zone_id
 
 Authors
 =======

--- a/data.tf
+++ b/data.tf
@@ -25,16 +25,17 @@ data "aws_iam_policy_document" "bucket_policy_document" {
 }
 
 resource "aws_s3_bucket" "bucket" {
+  provider      = "aws.s3"
   bucket        = "${var.bucket_name}"
   acl           = "${var.bucket_acl}"
-  region        = "${data.aws_region.region.name}"
+  region        = "${data.aws_region.s3_region.name}"
   force_destroy = "${var.bucket_force_destroy}"
   policy        = "${data.aws_iam_policy_document.bucket_policy_document.json}"
 
   cors_rule {
     allowed_headers = "${var.bucket_cors_allowed_headers}"
     allowed_methods = "${var.bucket_cors_allowed_methods}"
-    allowed_origins = "${var.bucket_cors_allowed_origins}"
+    allowed_origins = ["${compact(distinct(concat(list(var.cloudfront_fqdn), var.cloudfront_aliases, var.bucket_cors_extra_allowed_origins)))}"]
     expose_headers  = "${var.bucket_cors_expose_headers}"
     max_age_seconds = "${var.bucket_cors_max_age_seconds}"
   }
@@ -42,7 +43,3 @@ resource "aws_s3_bucket" "bucket" {
 
 
 # outputs from data tier
-
-output "s3_bucket_domain_name" {
-  value = "${aws_s3_bucket.bucket.bucket_domain_name}"
-}

--- a/edge.tf
+++ b/edge.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
   is_ipv6_enabled     = "${var.cloudfront_ipv6_enabled}"
   comment             = "${var.cloudfront_comment}"
   default_root_object = "${var.cloudfront_default_root_object}"
-  aliases             = "${var.cloudfront_aliases}"
+  aliases             = ["${compact(distinct(concat(list(var.cloudfront_fqdn),var.cloudfront_aliases)))}"]
   price_class         = "${var.cloudfront_price_class}"
 
   default_cache_behavior {
@@ -59,7 +59,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
     viewer_protocol_policy = "${var.cloudfront_default_cache_viewer_protocol_policy}"
 
     forwarded_values {
-      query_string = "${var.cloudfront_default_cache_forwarded_values}"
+      query_string = "${var.cloudfront_default_cache_forwarded_values_query_string}"
 
       cookies {
         forward = "${var.cloudfront_default_cache_forwarded_cookies}"
@@ -74,23 +74,19 @@ resource "aws_cloudfront_distribution" "cloudfront" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = "${data.aws_acm_certificate.cert.arn}"
-    minimum_protocol_version = "${var.cloudfront_viewer_cert_min_supported_version}"
-    ssl_support_method       = "${var.cloudfront_viewer_cert_ssl_support_method}"
+    acm_certificate_arn      = "${data.aws_acm_certificate.cloudfront.arn}"
+    minimum_protocol_version = "${var.cloudfront_cert_min_supported_version}"
+    ssl_support_method       = "${var.cloudfront_cert_ssl_support_method}"
   }
 }
 
 
 # outputs from edge tier
 
-output "cloudfront_fqdn" {
+output "cloudfront_domain_name" {
   value = "${aws_cloudfront_distribution.cloudfront.domain_name}"
 }
 
-output "cloudfront_a_record" {
-  value = "${aws_route53_record.cloudfront_a.fqdn}"
-}
-
-output "cloudfront_s3_bucket_source_path" {
-  value = "${aws_s3_bucket.bucket.bucket_domain_name}/${var.cloudfront_origin_path}"
+output "cloudfront_id" {
+  value = "${aws_cloudfront_distribution.cloudfront.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,31 @@
 # MAIN
 
 provider "aws" {
-  alias   = "provided"
+  alias   = "us-east-1"
   profile = "${var.aws_profile}"
   region  = "us-east-1"
 }
 
-data "aws_region" "region" {
+provider "aws" {
+  alias   = "s3"
+  profile = "${var.aws_profile}"
+  region  = "${var.s3_region}"
+}
+
+data "aws_region" "us-east-1" {
   name = "us-east-1"
 }
 
-data "aws_route53_zone" "zone" {
-  name = "${var.dns_toplevel_zone}."
+data "aws_region" "s3_region" {
+  name = "${var.s3_region}"
 }
 
-data "aws_acm_certificate" "cert" {
-  provider = "aws.provided"
-  domain   = "${var.cloudfront_viewer_acm_cert_domain}"
+data "aws_route53_zone" "zone" {
+  name = "${var.route53_toplevel_zone}."
+}
+
+data "aws_acm_certificate" "cloudfront" {
+  provider = "aws.us-east-1"
+  domain   = "${var.cloudfront_acm_cert_domain}"
   statuses = ["ISSUED"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,19 +4,14 @@ variable "aws_profile" {
   default     = "default"
 }
 
-variable "region" {
-  type        = "string"
-  description = "AWS region"
-}
-
-variable "short_name" {
-  description = "Short name to be used for name prefix for backend resources"
-  type = "string"
-}
-
 variable "bucket_name" {
   description = "Full name for S3 bucket"
   type = "string"
+}
+
+variable "s3_region" {
+  type        = "string"
+  description = "AWS region for S3 bucket"
 }
 
 variable "cloudfront_fqdn" {
@@ -25,7 +20,12 @@ variable "cloudfront_fqdn" {
   default = ""
 }
 
-variable "dns_toplevel_zone" {
+variable "cloudfront_acm_cert_domain" {
+  description = "ACM domain to lookup for cert for cloudfront web distribution"
+  type = "string"
+}
+
+variable "route53_toplevel_zone" {
   description = "The top level zone for DNS"
   type        = "string"
 }
@@ -51,8 +51,9 @@ variable "bucket_cors_allowed_methods" {
   default = ["GET", "HEAD"]
 }
 
-variable "bucket_cors_allowed_origins" {
+variable "bucket_cors_extra_allowed_origins" {
   type = "list"
+  default = []
 }
 
 variable "bucket_cors_expose_headers" {
@@ -118,7 +119,8 @@ variable "cloudfront_default_cache_viewer_protocol_policy" {
   default = "redirect-to-https"
 }
 
-variable "cloudfront_default_cache_forwarded_values" {
+variable "cloudfront_default_cache_forwarded_values_query_string" {
+  description = "Indicates whether you want CloudFront to forward query strings to the origin that is associated with this cache behavior."
   default = false
 }
 
@@ -130,16 +132,11 @@ variable "cloudfront_geo_restriction_type" {
   default = "none"
 }
 
-variable "cloudfront_viewer_acm_cert_domain" {
-  description = "ACM domain to lookup for cert for cloudfront web distribution"
-  type = "string"
-}
-
-variable "cloudfront_viewer_cert_min_supported_version" {
+variable "cloudfront_cert_min_supported_version" {
   default = "TLSv1"
 }
 
-variable "cloudfront_viewer_cert_ssl_support_method" {
+variable "cloudfront_cert_ssl_support_method" {
   default = "sni-only"
 }
 


### PR DESCRIPTION
- update variable names for clarity
- combine variables where possible (cloudfront_aliases and
  bucket_cors_allowed_origins)
- require s3_region be passed in - S3 can be in a different region than
  us-east-1
- update Readme